### PR TITLE
Fix Project and Project Lead issues

### DIFF
--- a/code/TaskManager/Views/Admin/EditProject.cshtml
+++ b/code/TaskManager/Views/Admin/EditProject.cshtml
@@ -22,11 +22,8 @@
 
         <div class="form-group">
             <label asp-for="ProjectLeadId">Project Lead</label>
-            <select asp-for="ProjectLeadId" class="form-control">
-                @foreach (var user in ViewBag.ProjectLeads)
-                {
-                    <option value="@user.Id">@user.UserName</option>
-                }
+            <select asp-for="ProjectLeadId" asp-items="ViewBag.ProjectLeads" class="form-control">
+                <option value="">-- Select a Lead --</option>
             </select>
             <span asp-validation-for="ProjectLeadId" class="text-danger"></span>
         </div>

--- a/code/TaskManager/Views/Employee/EditProject.cshtml
+++ b/code/TaskManager/Views/Employee/EditProject.cshtml
@@ -4,6 +4,13 @@
 
 <h2 class="text-center">Edit Project</h2>
 
+if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger text-center">
+        @TempData["ErrorMessage"]
+    </div>
+}
+
 <div class="form-container">
     <form asp-action="EditProject" method="post">
         <input type="hidden" asp-for="Id" />

--- a/code/TaskManager/Views/Employee/ProjectDetails.cshtml
+++ b/code/TaskManager/Views/Employee/ProjectDetails.cshtml
@@ -2,6 +2,13 @@
 
 <link rel="stylesheet" href="~/css/Manager/manager_projectDetails.css" asp-append-version="true" />
 
+@if (TempData["RemoveGroupMessage"] != null)
+{
+    <div class="alert alert-danger text-center">
+        @TempData["RemoveGroupMessage"]
+    </div>
+}
+
 <div class="center-content">
     <h2>Project Details</h2>
 
@@ -17,7 +24,7 @@
                 <li class="group-item">
                     <span class="group-name">@groupProject.Group.Name</span>
 
-                    @if (Model.ProjectCreatorId == int.Parse(ViewBag.UserId) || Model.ProjectLeadId == int.Parse(ViewBag.UserId))
+                    @if (Model.ProjectLeadId == int.Parse(ViewBag.UserId))
                     {
                         <form asp-action="RemoveGroupFromProject" method="post" style="display:inline;">
                             <input type="hidden" name="projectId" value="@Model.Id" />
@@ -30,7 +37,7 @@
         </ul>
     </div>
 
-    @if (Model.ProjectCreatorId == int.Parse(ViewBag.UserId) || Model.ProjectLeadId == int.Parse(ViewBag.UserId))
+    @if (Model.ProjectLeadId == int.Parse(ViewBag.UserId))
     {
         <h4>Assign Group to Project</h4>
         <form asp-action="AssignGroupToProject" method="post">

--- a/code/TaskManager/Views/Project/EditTask.cshtml
+++ b/code/TaskManager/Views/Project/EditTask.cshtml
@@ -104,27 +104,6 @@
                                                aria-expanded="false" aria-controls="replyCollapse_@comment.Id"
                                                style="opacity: 1; color: inherit;">Reply</a>
                                         </p>
-                                        <!-- Collapsible reply form -->
-                                        <div class="collapse mt-2" id="replyCollapse_@comment.Id">
-                                            <div class="card card-body p-2">
-                                                <form asp-action="ReplyToComment" method="post">
-                                                    @Html.AntiForgeryToken()
-                                                    <input type="hidden" name="parentCommentId" value="@comment.Id" />
-                                                    <input type="hidden" name="taskId" value="@Model.TaskId" />
-                                                    <div class="mb-2">
-                                                        <input type="text" name="content" class="form-control" placeholder="Write a reply..." />
-                                                    </div>
-                                                    <button type="submit" class="btn btn-primary btn-sm">Post Reply</button>
-                                                </form>
-                                            </div>
-                                        </div>
-                                        <!-- Render replies recursively if any -->
-                                        @if (comment.Replies != null && comment.Replies.Any())
-                                        {
-                                            <div class="ps-4">
-                                                @Html.Raw(RenderReplies(comment.Replies))
-                                            </div>
-                                        }
                                     </div>
                                 }
                             }

--- a/code/TaskManager/Views/Shared/_ProjectGroupAssignmentPartial.cshtml
+++ b/code/TaskManager/Views/Shared/_ProjectGroupAssignmentPartial.cshtml
@@ -3,6 +3,14 @@
 @{
     Layout = null;
 }
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger text-center">
+        @TempData["ErrorMessage"]
+    </div>
+}
+
+
 <div id="group-assignment-container">
     <div class="assigned-groups">
         <h3>Assigned Groups</h3>


### PR DESCRIPTION
Updated ProjectLead Behavior
Removed Reply Button, closes https://github.com/ahmadhzUWG/Capstone-Project/issues/125

Fixed feedback:
project should always have at least one group and the project lead should be the manager of a group on the project.
*when changing project lead it should display only managers
*when changing manager of a group it should also update project lead appropriately
*when deleting a group it should prevent deletion if the manager is also a project lead, closes https://github.com/ahmadhzUWG/Capstone-Project/issues/119